### PR TITLE
Fixed secretz.js solution to print hashes on separate lines

### DIFF
--- a/problems/secretz/solution.js
+++ b/problems/secretz/solution.js
@@ -8,9 +8,9 @@ parser.on('entry', function (e) {
     if (e.type !== 'File') return;
     
     var h = crypto.createHash('md5', { encoding: 'hex' });
-    e.pipe(h).pipe(through(null, end)).pipe(process.stdout);
+    e.pipe(h).pipe(through(write)).pipe(process.stdout);
     
-    function end () { this.queue(' ' + e.path + '\n') }
+    function write(buf) { this.queue(buf.toString() + ' ' + e.path + '\n') }
 });
 
 var cipher = process.argv[2];


### PR DESCRIPTION
The current solution prints all the hashes on the same line.

    $ cat my.tar | node program.js aes256 kjdfl
    b1946ac92492d2347c6235b4d2611184b1946ac92492d2347c6235b4d2611184890e9c28722fd07e99df03904f5b556f     hello.tx3
     hello.txt
     program.js

After the fix the output is correct.

    $ cat my.tar | node program.js aes256 kjdfl
    b1946ac92492d2347c6235b4d2611184 hello.tx3
    b1946ac92492d2347c6235b4d2611184 hello.txt
    890e9c28722fd07e99df03904f5b556f program.js