### PR TITLE
Updates terminal-menu version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "optimist": "~0.5.2",
         "through": "~2.3.4",
         "tuple-stream": "~0.0.2",
-        "terminal-menu": "~0.0.0",
+        "terminal-menu": "~0.2.0",
         "split": "~0.2.5",
         "duplexer": "~0.1.1",
         "concat-stream": "~1.0.0",


### PR DESCRIPTION
Version 0.2.0 of terminal-menu has been updated to add vi-style navigation. Can we bring some of that goodness back to stream-adventure? This would allow for consistent navigation between NodeSchool.io lessons.