### PR TITLE
Split lines in secretz solution to get just one md5 per line

### DIFF
--- a/problems/secretz/solution.js
+++ b/problems/secretz/solution.js
@@ -2,14 +2,18 @@ var crypto = require('crypto');
 var tar = require('tar');
 var zlib = require('zlib');
 var through = require('through');
+var split = require('split');
 
 var parser = tar.Parse();
 parser.on('entry', function (e) {
     if (e.type !== 'File') return;
-    
+
     var h = crypto.createHash('md5', { encoding: 'hex' });
-    e.pipe(h).pipe(through(null, end)).pipe(process.stdout);
-    
+    e.pipe(h)
+      .pipe(split())
+      .pipe(through(null, end))
+      .pipe(process.stdout);
+
     function end () { this.queue(' ' + e.path + '\n') }
 });
 

--- a/test/solutions/secretz.js
+++ b/test/solutions/secretz.js
@@ -2,14 +2,18 @@ var crypto = require('crypto');
 var tar = require('tar');
 var zlib = require('zlib');
 var through = require('through');
+var split = require('split');
 
 var parser = tar.Parse();
 parser.on('entry', function (e) {
     if (e.type !== 'File') return;
-    
+
     var h = crypto.createHash('md5', { encoding: 'hex' });
-    e.pipe(h).pipe(through(null, end)).pipe(process.stdout);
-    
+    e.pipe(h)
+      .pipe(split())
+      .pipe(through(null, end))
+      .pipe(process.stdout);
+
     function end () { this.queue(' ' + e.path + '\n') }
 });
 


### PR DESCRIPTION
The current solution is failing a correct solution since it's getting both md5 values on the first line.
I've added split so it gets one line at a time.
This is how it looks when running stream-adventure verify solution.js, EXPECTED is the old solution, ACTUAL is the solution proposed in this PR:

```
ACTUAL:   "97911dcc607865d621029f6f927c7851 secretz/METADATA.TXT"
EXPECTED: "97911dcc607865d621029f6f927c78512cdcfa9f8bbefb82fb7a894964b5c199 secretz/METADATA.TXT"

ACTUAL:   "2cdcfa9f8bbefb82fb7a894964b5c199 secretz/SPYING.TXT"
EXPECTED: " secretz/SPYING.TXT"

ACTUAL:   ""
EXPECTED: ""

# FAIL

Your solution didn't match the expected output.
Try again, or run `stream-adventure run program.js` to see your solution's output.
```