### PR TITLE
added clarification for objectives of the 'duplexer redux' lesson

### DIFF
--- a/problems/duplexer_redux/problem.txt
+++ b/problems/duplexer_redux/problem.txt
@@ -6,15 +6,22 @@ argument to your program:
         // and pass through `counter` on the readable side
     };
 
-Return a duplex stream with the `counter` as the readable side. You will be
-written objects with a 2-character `country` field as input, such as these:
- 
+Return a duplex stream with the `counter` as the readable side. On the writeable
+side you will be sent location objects, each with a 2-character `country` field,
+such as these:
+
     {"short":"OH","name":"Ohio","country":"US"}
     {"name":"West Lothian","country":"GB","region":"Scotland"}
     {"short":"NSW","name":"New South Wales","country":"AU"}
+    {"country":"US","name":"Texas","short":"TX"}
 
-Create an object to keep a count of all the countries in the input. Once the
-input ends, call `counter.setCounts()` with your country counts.
+Create an object to keep a count of the number of location objects that are
+written for each country, like this:
+
+    { US: 2, GB: 1, AU: 1 }
+
+Once the input ends, call `counter.setCounts()` passing in your country count
+object.
 
 The `duplexer` module will again be very handy in this example.
 


### PR DESCRIPTION
I was really enjoying these lessons until I reached the "Duplexer Redux" module.  The problem outline didn't give me any real sense of what I was supposed to do, and I was basically forced to look at the solution to figure out what I was supposed to do.  I tried to add some clarity to the problem description with changes to wording and examples.