### PR TITLE
Fix verification of HTTP SERVER exercise

### DIFF
--- a/problems/http_server/setup.js
+++ b/problems/http_server/setup.js
@@ -26,7 +26,7 @@ module.exports = function (opts) {
         ps.stderr.pipe(process.stderr);
         close.push(function () { ps.kill() });
         
-        var stream = check(aPort);
+        var stream = check(port);
         if (opts.run) {
             ps.stdout.pipe(process.stdout);
             stream.on('end', function () { ps.kill() });


### PR DESCRIPTION
Hey there,

The `setup.js` incorrectly binds both the submission and solution clients on a single port (`aPort` instead of `port`), which *should* screw up for everyone, everytime, on `verify`.  This seems to work, unexpectedly, for most people (can't fathom why), but it does break for several people (which is should!).

Just checking on the proper port helps.