### PR TITLE
Fix bad exit code test

### DIFF
--- a/problems/http_server/index.js
+++ b/problems/http_server/index.js
@@ -27,10 +27,7 @@ exports.verify = verify({ modeReset: true }, function (args, t) {
     
     ps.stderr.pipe(process.stderr);
     ps.stdout.pipe(process.stdout);
-    ps.once('exit', function (code) {
-        t.equal(Number(code), 0, 'successful exit code');
-    });
-    
+        
     (function retry (n) {
         if (n > 6) return t.fail('server not running');
         


### PR DESCRIPTION
Removed the check for successful exit, because node when killed gives a
non-zero exit code. On my machine with node 0.10, it gives 143, and with
node 0.8, it gives 1.
The test doesn't seem that useful anyway, since the actual checks will
fail if the server exits without working