### PR TITLE
Fix run in lines exercise

### DIFF
--- a/problems/lines/index.js
+++ b/problems/lines/index.js
@@ -69,7 +69,7 @@ exports.run = function (args) {
     
     var iv = setInterval(function () {
         if (input.length) {
-            ps.stdin.write(input.shift());
+            ps.stdin.write(input.shift() + '\n');
         }
         else {
             clearInterval(iv);


### PR DESCRIPTION
As #132 and others detail, the current runner for `lines` is faulty: it forgets to inject newlines in `stdin`, resulting in a single line every time. This makes debugging one's solution super hard, as the runner doesn't comply with the problem's text.

I just sync'd the runner's logic with the verifier's.