### PR TITLE
change wording from module to program

### DIFF
--- a/problems/crypt/problem.txt
+++ b/problems/crypt/problem.txt
@@ -1,4 +1,4 @@
-Your module will be given a passphrase on `process.argv[2]` and 'aes256'
+Your program will be given a passphrase on `process.argv[2]` and 'aes256'
 encrypted data will be written to stdin.
 
 Simply decrypt the data and stream the result to process.stdout.


### PR DESCRIPTION
When I ran through this tutorial I couldn't understand why the usual module.exports routine wasn't working until I tried just stripping that out and making it a regular script. The use of the word 'module' in the instructions is what lead me astray.